### PR TITLE
modifying tab style on infoWindow

### DIFF
--- a/build/style.css
+++ b/build/style.css
@@ -681,7 +681,7 @@ textarea.materialize-textarea {
 }
 
 .tabs .tab a:hover, .tabs .tab a.active {
-    background-color: transparent;
+    background-color: rgba(38, 166, 153, 0.329);
     color: var(--blue);
 }
 .tabs .tab a {


### PR DESCRIPTION
On the QHAWAX map, when you click on the leaf on the map, it took me a while to figure out that in the pop out INCA, REAL TIME, WEATHER, and GRAPHICS were buttons that I could press to navigate to see more fields

I suggested making the INCA appear toggled to make it clearer to users that they are not headings

Additional context
old behavior:
Screen Shot 2021-10-01 at 3 36 01 PM

new behavior:
Screen Shot 2021-10-01 at 3 36 14 PM